### PR TITLE
lab 3: fix keyboard_controller.py joint order to match lab manual

### DIFF
--- a/lab3_ur7e/src/joint_control/joint_control/keyboard_controller.py
+++ b/lab3_ur7e/src/joint_control/joint_control/keyboard_controller.py
@@ -19,8 +19,8 @@ class KeyboardController(Node):
         super().__init__('ur7e_keyboard_controller')
         
         self.joint_names = [
-            'shoulder_lift_joint', 'elbow_joint', 'wrist_1_joint',
-            'wrist_2_joint', 'wrist_3_joint', 'shoulder_pan_joint'
+            'shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint',
+            'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint'
         ]
         self.joint_positions = [0.0]*6
         self.got_joint_states = False  # Failsafe: don't publish until joint states received


### PR DESCRIPTION
This should prevent students who fail to notice that they have to change the order of joint_names from hitting the pedestal when they input the coordinates in the lab manual.